### PR TITLE
fix(readme): Typo update 'Dart' to 'Dark'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ There are two ways how you can use `<dark-mode>`:
 
 ```html
 <dark-mode></dark-mode>
-<dark-mode light="Dart" dark="Light"></dark-mode>
+<dark-mode light="DarK" dark="Light"></dark-mode>
 <dark-mode dark="Dark" light="Light" style="border: 1px solid red; font-size: 12px;"></dark-mode>
 ```
 
@@ -44,7 +44,7 @@ import '@wcj/dark-mode';
 function Demo() {
   return (
     <div>
-      <dark-mode light="Dart" dark="Light"></dark-mode>
+      <dark-mode light="DarK" dark="Light"></dark-mode>
     </div>
   );
 }


### PR DESCRIPTION
Seems that this should be Dark, rather than Dart. I noticed this seemingly typo by someone else using this package, then found that it is in the package documentation too.

This readme file seems to be the only place that this typo exists
![dart-dark](https://user-images.githubusercontent.com/43322309/160295471-32ffbab7-742d-4390-94ea-60519edfad27.png)

